### PR TITLE
Upgrade to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
   tag:
     description: 'The found tag'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
 branding:
   icon: 'hash'


### PR DESCRIPTION
Upgrade to node 20 because node16 is deprecated by GitHub Action.
Solving https://github.com/jimschubert/query-tag-action/issues/9